### PR TITLE
add `await Model.init()` to avoid race condition where collection may not exist when calling `insertMany()`

### DIFF
--- a/template/app.js
+++ b/template/app.js
@@ -45,6 +45,7 @@ const loadData = async () => {
       },
     ),
   );
+  await Movie.init();
 
   const movies = require("./movies.json");
   console.log(


### PR DESCRIPTION
In this project, Mongoose automatically calls `createCollection()` in the background when you call `mongoose.model()` because you have `autoCreate` option set to true here: https://github.com/datastax/create-astradb-mongoose-app/blob/80410ebf1cc9fd7c9345688b9396e3384461796d/template/astradb-mongoose.js#L12 . But Mongoose doesn't wait for `createCollection()` to finish before sending [this `insertMany()`](https://github.com/datastax/create-astradb-mongoose-app/blob/80410ebf1cc9fd7c9345688b9396e3384461796d/template/app.js#L54), so the `insertMany()` call may fail as Yuqi noted in Slack.